### PR TITLE
[Feat] 플로팅 버튼 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,15 +1157,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
-    "node_modules/babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha512-KpgoA8VE/pMmNCrnEeeXqFG24TIH11Z3ZaimIhJWsin8EbfZy3WzFKUTIan10ZIDgRVvi9EkLbruJElJC9dRlg==",
-      "peer": true,
-      "dependencies": {
-        "core-js": "^1.0.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1364,13 +1355,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "peer": true
     },
     "node_modules/core-js-pure": {
       "version": "3.23.1",
@@ -5846,15 +5830,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
-    "babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha512-KpgoA8VE/pMmNCrnEeeXqFG24TIH11Z3ZaimIhJWsin8EbfZy3WzFKUTIan10ZIDgRVvi9EkLbruJElJC9dRlg==",
-      "peer": true,
-      "requires": {
-        "core-js": "^1.0.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6000,12 +5975,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-      "peer": true
     },
     "core-js-pure": {
       "version": "3.23.1",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,13 +1,7 @@
+import React from 'react';
 import styled from 'styled-components';
 
-interface IButtonStyle {
-  primary?: boolean;
-}
-
-interface IButton extends IButtonStyle {
-  onClick?: () => void;
-  content: string;
-}
+import { IButtonStyle, IButton } from '@/types/Button';
 
 const ButtonStyle = styled.button<IButtonStyle>`
   cursor: pointer;

--- a/src/components/FloatingButton/FloatingOpenMenuButton.tsx
+++ b/src/components/FloatingButton/FloatingOpenMenuButton.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+import { IButton } from '../../types/Button';
+
+import { FloatingButtonStyle } from './index';
+
+const FloatingOpenMenuButtonStyle = styled(FloatingButtonStyle)`
+  position: fixed;
+  bottom: 5rem;
+  right: 2rem;
+  color: whitesmoke;
+`;
+
+const FloatingOpenMenuButton = ({ content, onClick, primary }: IButton) => (
+  <FloatingOpenMenuButtonStyle
+    onClick={onClick}
+    primary={primary}
+  >
+    {content}
+  </FloatingOpenMenuButtonStyle>
+);
+export default FloatingOpenMenuButton;

--- a/src/components/FloatingButton/index.tsx
+++ b/src/components/FloatingButton/index.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+import { IButton, IButtonStyle } from '../../types/Button';
+
+export const FloatingButtonStyle = styled.button<IButtonStyle>`
+  z-index: 100;
+  font-size: 1rem;
+  color: #222;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: 1px solid #bbb;
+  cursor: pointer;
+  box-shadow: 1px 1px 3px 1px #00000029;
+  background-color: ${({ primary }) => (primary ? 'coral' : '')};
+`;
+
+const FloatingButton = ({ content, onClick, primary }: IButton) => (
+  <FloatingButtonStyle
+    onClick={onClick}
+    primary={primary}
+  >
+    {content}
+  </FloatingButtonStyle>
+);
+
+export default FloatingButton;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,26 +1,60 @@
+import { SyntheticEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PageContainer } from '@/CommonStyles';
-import Button from '@/components/Button';
+// eslint-disable-next-line import/no-unresolved
+import FloatingButton from '@/components/FloatingButton';
+import FloatingOpenMenuButton from '@/components/FloatingButton/FloatingOpenMenuButton';
 import Layout from '@/components/Layout';
 
 const Contents = styled.div``;
 
+const FloatMenus = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1.4rem;
+  position: absolute;
+  bottom: 10rem;
+  right: 2rem;
+  width: 3.5rem;
+  height: fit-content;
+  color: #222;
+  font-size: 1.6rem;
+`;
+
 const Main = () => {
   const navigate = useNavigate();
+  const [floatingMenuOpen, setFloatingMenuOpen] = useState(false);
 
   const goCreatePage = () => navigate('/create');
+  const openFloatingMenu = (e: SyntheticEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setFloatingMenuOpen(true);
+  };
 
   return (
     <Layout title='스터디 목록'>
-      <PageContainer>
+      <PageContainer onClick={() => setFloatingMenuOpen(false)}>
         <Contents />
-        <Button
+        <FloatingOpenMenuButton
+          content='M'
           primary
-          content='스터디 생성'
-          onClick={goCreatePage}
+          onClick={openFloatingMenu}
         />
+        {floatingMenuOpen && (
+          <FloatMenus onClick={(e) => e.stopPropagation()}>
+            <FloatingButton
+              content='입장'
+              onClick={(e: SyntheticEvent<HTMLButtonElement>) => e.stopPropagation()}
+            />
+            <FloatingButton
+              content='생성'
+              onClick={goCreatePage}
+            />
+          </FloatMenus>
+        )}
       </PageContainer>
     </Layout>
   );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -33,10 +33,11 @@ const Main = () => {
     e.stopPropagation();
     setFloatingMenuOpen(true);
   };
+  const closeFloatingMenu = () => setFloatingMenuOpen(false);
 
   return (
     <Layout title='스터디 목록'>
-      <PageContainer onClick={() => setFloatingMenuOpen(false)}>
+      <PageContainer onClick={closeFloatingMenu}>
         <Contents />
         <FloatingOpenMenuButton
           content='M'

--- a/src/types/Button.ts
+++ b/src/types/Button.ts
@@ -1,0 +1,9 @@
+export interface IButtonStyle {
+  primary?: boolean;
+}
+
+export interface IButton extends IButtonStyle {
+  /* eslint-disable-next-line */
+  onClick?: (e: React.SyntheticEvent<HTMLButtonElement>) => void;
+  content: string;
+}


### PR DESCRIPTION
스터디 리스트 페이지에서 플로팅 메뉴 버튼 추가
  - 클릭 시 버튼 상단에 입장, 생성 버튼 존재
  
![image](https://user-images.githubusercontent.com/2215762/176247623-f1f0fb44-e67b-447d-bdbe-d70bc7d5eef9.png)

![image](https://user-images.githubusercontent.com/2215762/176247674-32be0215-2597-49ed-bf00-dcf5684fa8ab.png)

버튼 타입 파일 분리
  - 플로팅 버튼과 여러 버튼에서 동일한 타입을 사용하여 한 곳에서 관리할 수 있도록 types 폴더를 만들어 추가하였습니다.
  
![image](https://user-images.githubusercontent.com/2215762/176247781-f7e801cd-d937-4eba-b7ae-b2b7de446f9f.png)
